### PR TITLE
tests pass when ran repeatedly, abstract out string prop validation

### DIFF
--- a/data/creator.js
+++ b/data/creator.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class Creator {
   constructor(client) {
     this.client = client;
@@ -25,11 +27,7 @@ export default class Creator {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",

--- a/data/merger.js
+++ b/data/merger.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class Merger {
   constructor(client) {
     this.client = client;
@@ -20,11 +22,7 @@ export default class Merger {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with withClassName(className)",

--- a/data/updater.js
+++ b/data/updater.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class Updater {
   constructor(client) {
     this.client = client;
@@ -20,11 +22,7 @@ export default class Updater {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with withId(id)",

--- a/data/validator.js
+++ b/data/validator.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class Validator {
   constructor(client) {
     this.client = client;
@@ -20,11 +22,7 @@ export default class Validator {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",

--- a/schema/classDeleter.js
+++ b/schema/classDeleter.js
@@ -1,4 +1,4 @@
-import { DEFAULT_KIND, validateKind } from "../kinds";
+import { isValidStringProperty } from "../validation/string";
 
 export default class ClassDeleter {
   constructor(client) {
@@ -12,11 +12,7 @@ export default class ClassDeleter {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",

--- a/schema/classGetter.js
+++ b/schema/classGetter.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class ClassGetter {
   constructor(client) {
     this.client = client;
@@ -10,11 +12,7 @@ export default class ClassGetter {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",

--- a/schema/propertyCreator.js
+++ b/schema/propertyCreator.js
@@ -1,4 +1,5 @@
 import { DEFAULT_KIND, validateKind } from "../kinds";
+import { isValidStringProperty } from "../validation/string";
 
 export default class ClassCreator {
   constructor(client) {
@@ -17,11 +18,7 @@ export default class ClassCreator {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",

--- a/schema/shardUpdater.js
+++ b/schema/shardUpdater.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class ShardUpdater {
   constructor(client) {
     this.client = client;
@@ -10,11 +12,7 @@ export default class ShardUpdater {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",
@@ -28,11 +26,7 @@ export default class ShardUpdater {
   };
 
   validateShardName = () => {
-    if (
-      this.shardName == undefined ||
-      this.shardName == null ||
-      this.shardName.length == 0
-    ) {
+    if (!isValidStringProperty(this.shardName)) {
       this.errors = [
         ...this.errors,
         "shardName must be set - set with .withShardName(shardName)",
@@ -46,11 +40,7 @@ export default class ShardUpdater {
   }
 
   validateStatus = () => {
-    if (
-      this.status == undefined ||
-      this.status == null ||
-      this.status.length == 0
-    ) {
+    if (!isValidStringProperty(this.status)) {
       this.errors = [
         ...this.errors,
         "status must be set - set with .withStatus(status)",

--- a/schema/shardsGetter.js
+++ b/schema/shardsGetter.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class ShardsGetter {
   constructor(client) {
     this.client = client;
@@ -10,11 +12,7 @@ export default class ShardsGetter {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",

--- a/schema/shardsUpdater.js
+++ b/schema/shardsUpdater.js
@@ -1,3 +1,4 @@
+import { isValidStringProperty } from "../validation/string";
 import { getShards } from "./shardsGetter";
 import { updateShard } from "./shardUpdater";
 
@@ -14,11 +15,7 @@ export default class ShardsUpdater {
   };
 
   validateClassName = () => {
-    if (
-      this.className == undefined ||
-      this.className == null ||
-      this.className.length == 0
-    ) {
+    if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
         "className must be set - set with .withClassName(className)",
@@ -32,11 +29,7 @@ export default class ShardsUpdater {
   }
 
   validateStatus = () => {
-    if (
-      this.status == undefined ||
-      this.status == null ||
-      this.status.length == 0
-    ) {
+    if (!isValidStringProperty(this.status)) {
       this.errors = [
         ...this.errors,
         "status must be set - set with .withStatus(status)",

--- a/validation/string.js
+++ b/validation/string.js
@@ -1,0 +1,4 @@
+export function isValidStringProperty(input) {
+    return typeof input == "string" &&
+      input.length > 0
+}


### PR DESCRIPTION
### Changes

- Fix schema tests so they may be ran repeatedly without restarting test env
- Abstracted out string property validation