### PR TITLE
Update /objects endpoints to include class name in path

### DIFF
--- a/data/checker.js
+++ b/data/checker.js
@@ -1,4 +1,4 @@
-import { buildObjectsPath } from "./path"
+import { buildObjectsPath } from "./path";
 
 export default class Checker {
   constructor(client) {

--- a/data/checker.js
+++ b/data/checker.js
@@ -1,3 +1,5 @@
+import { buildObjectsPath } from "./path"
+
 export default class Checker {
   constructor(client) {
     this.client = client;
@@ -6,6 +8,11 @@ export default class Checker {
 
   withId = (id) => {
     this.id = id;
+    return this;
+  };
+
+  withClassName = (className) => {
+    this.className = className;
     return this;
   };
 
@@ -34,7 +41,7 @@ export default class Checker {
     }
     this.validate();
 
-    const path = `/objects/${this.id}`;
+    const path = buildObjectsPath(this.id, this.className);
     return this.client.head(path);
   };
 }

--- a/data/deleter.js
+++ b/data/deleter.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class Deleter {
   constructor(client) {
     this.client = client;
@@ -8,6 +10,19 @@ export default class Deleter {
     this.id = id;
     return this;
   };
+
+  withClassName = (className) => {
+    this.className = className;
+    return this;
+  }
+
+  buildPath = () => {
+    let path = `/objects`;
+    if (isValidStringProperty(this.className)) {
+      path = `${path}/${this.className}`
+    }
+    return `/${path}/${this.id}`;
+  }
 
   validateIsSet = (prop, name, setter) => {
     if (prop == undefined || prop == null || prop.length == 0) {
@@ -34,7 +49,7 @@ export default class Deleter {
     }
     this.validate();
 
-    const path = `/objects/${this.id}`;
+    const path = this.buildPath();
     return this.client.delete(path);
   };
 }

--- a/data/deleter.js
+++ b/data/deleter.js
@@ -1,4 +1,4 @@
-import { buildObjectsPath } from "./path"
+import { buildObjectsPath } from "./path";
 
 export default class Deleter {
   constructor(client) {

--- a/data/deleter.js
+++ b/data/deleter.js
@@ -1,4 +1,4 @@
-import { isValidStringProperty } from "../validation/string";
+import { buildObjectsPath } from "./path"
 
 export default class Deleter {
   constructor(client) {
@@ -14,14 +14,6 @@ export default class Deleter {
   withClassName = (className) => {
     this.className = className;
     return this;
-  }
-
-  buildPath = () => {
-    let path = `/objects`;
-    if (isValidStringProperty(this.className)) {
-      path = `${path}/${this.className}`
-    }
-    return `/${path}/${this.id}`;
   }
 
   validateIsSet = (prop, name, setter) => {
@@ -49,7 +41,7 @@ export default class Deleter {
     }
     this.validate();
 
-    const path = this.buildPath();
+    const path = buildObjectsPath(this.id, this.className);
     return this.client.delete(path);
   };
 }

--- a/data/getterById.js
+++ b/data/getterById.js
@@ -1,4 +1,4 @@
-import { buildObjectsPath } from "./path"
+import { buildObjectsPath } from "./path";
 
 export default class GetterById {
   constructor(client) {

--- a/data/getterById.js
+++ b/data/getterById.js
@@ -1,4 +1,4 @@
-import { isValidStringProperty } from "../validation/string";
+import { buildObjectsPath } from "./path"
 
 export default class GetterById {
   constructor(client) {
@@ -16,14 +16,6 @@ export default class GetterById {
     this.className = className;
     return this;
   };
-
-  buildPath = () => {
-    let path = `/objects`;
-    if (isValidStringProperty(this.className)) {
-      path = `${path}/${this.className}`
-    }
-    return `/${path}/${this.id}`;
-  }
 
   extendAdditionals = (prop) => {
     this.additionals = [...this.additionals, prop];
@@ -60,7 +52,7 @@ export default class GetterById {
       );
     }
 
-    let path = this.buildPath();
+    let path = buildObjectsPath(this.id, this.className);
   
     if (this.additionals.length > 0) {
       path += `?include=${this.additionals.join(",")}`;

--- a/data/getterById.js
+++ b/data/getterById.js
@@ -1,3 +1,5 @@
+import { isValidStringProperty } from "../validation/string";
+
 export default class GetterById {
   constructor(client) {
     this.client = client;
@@ -9,6 +11,19 @@ export default class GetterById {
     this.id = id;
     return this;
   };
+
+  withClassName = (className) => {
+    this.className = className;
+    return this;
+  };
+
+  buildPath = () => {
+    let path = `/objects`;
+    if (isValidStringProperty(this.className)) {
+      path = `${path}/${this.className}`
+    }
+    return `/${path}/${this.id}`;
+  }
 
   extendAdditionals = (prop) => {
     this.additionals = [...this.additionals, prop];
@@ -45,7 +60,8 @@ export default class GetterById {
       );
     }
 
-    let path = `/objects/${this.id}`;
+    let path = this.buildPath();
+  
     if (this.additionals.length > 0) {
       path += `?include=${this.additionals.join(",")}`;
     }

--- a/data/journey.test.js
+++ b/data/journey.test.js
@@ -202,7 +202,7 @@ describe("data", () => {
       .withId("1565c06c-463f-466c-9092-5930dbac3887")
       .do()
       .catch(err => 
-        expect(err).toEqual("it should not have errord: usage error (500): {\"error\":[{\"message\":\"repo: object by id: index not found for class DoesNotExist\"}]}")
+        expect(err).toEqual("usage error (500): {\"error\":[{\"message\":\"repo: object by id: index not found for class DoesNotExist\"}]}")
       );
   });
 
@@ -369,6 +369,30 @@ describe("data", () => {
       setTimeout(resolve, 1000);
     });
   });
+
+  it("deletes a thing with class name", async () => {
+    const properties = { stringProp: "with-id" };
+    const id = "6781a974-cfbf-455d-ace8-f1dba4564230";
+
+    client.data
+      .creator()
+      .withClassName(thingClassName)
+      .withProperties(properties)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(properties);
+        expect(res.id).toEqual(id);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .deleter()
+      .withId(id)
+      .withClassName(thingClassName)
+      .do()
+      .catch((e) => fail("it should not have errord: " + e));
+  })
 
   it("verifies there are now fewer things (after delete)", () => {
     return Promise.all([

--- a/data/journey.test.js
+++ b/data/journey.test.js
@@ -354,10 +354,24 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
-  it("checks that object exists", () => {
+  it("checks that object exists by id only", () => {
     return client.data
       .checker()
       .withId("1565c06c-463f-466c-9092-5930dbac3887")
+      .do()
+      .then((exists) => {
+        if (!exists) {
+          fail("it should exist in DB")
+        }
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  });
+
+  it("checks that object exists by id and class name", () => {
+    return client.data
+      .checker()
+      .withId("1565c06c-463f-466c-9092-5930dbac3887")
+      .withClassName(thingClassName)
       .do()
       .then((exists) => {
         if (!exists) {

--- a/data/journey.test.js
+++ b/data/journey.test.js
@@ -178,6 +178,34 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
+  it("gets one thing by id with class name", () => {
+    return client.data
+      .getterById()
+      .withClassName(thingClassName)
+      .withId("1565c06c-463f-466c-9092-5930dbac3887")
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: "1565c06c-463f-466c-9092-5930dbac3887",
+            properties: { stringProp: "with-id" },
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  });
+
+  it("fails to get one thing by id with invalid class name", () => {
+    return client.data
+      .getterById()
+      .withClassName("DoesNotExist")
+      .withId("1565c06c-463f-466c-9092-5930dbac3887")
+      .do()
+      .catch(err => 
+        expect(err).toEqual("it should not have errord: usage error (500): {\"error\":[{\"message\":\"repo: object by id: index not found for class DoesNotExist\"}]}")
+      );
+  });
+
   it("gets one thing by id with all optional additional props", () => {
     return client.data
       .getterById()

--- a/data/journey.test.js
+++ b/data/journey.test.js
@@ -162,7 +162,7 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
-  it("gets one thing by id", () => {
+  it("gets one thing by id only", () => {
     return client.data
       .getterById()
       .withId("1565c06c-463f-466c-9092-5930dbac3887")
@@ -178,7 +178,7 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
-  it("gets one thing by id with class name", () => {
+  it("gets one thing by id and class name", () => {
     return client.data
       .getterById()
       .withClassName(thingClassName)
@@ -239,7 +239,7 @@ describe("data", () => {
       });
   });
 
-  it("updates a thing", () => {
+  it("updates a thing by id only", () => {
     const id = "1565c06c-463f-466c-9092-5930dbac3887";
     return client.data
       .getterById()
@@ -259,6 +259,31 @@ describe("data", () => {
       .then((res) => {
         expect(res.properties).toEqual({
           stringProp: "thing-updated",
+        });
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  });
+
+  it("updates a thing by id and class name", () => {
+    const id = "1565c06c-463f-466c-9092-5930dbac3887";
+    return client.data
+      .getterById()
+      .withId(id)
+      .withClassName(thingClassName)
+      .do()
+      .then((res) => {
+        const properties = res.properties;
+        properties.stringProp = "thing-updated-with-class-name";
+        return client.data
+          .updater()
+          .withId(id)
+          .withClassName(thingClassName)
+          .withProperties(properties)
+          .do();
+      })
+      .then((res) => {
+        expect(res.properties).toEqual({
+          stringProp: "thing-updated-with-class-name",
         });
       })
       .catch((e) => fail("it should not have errord: " + e));
@@ -342,7 +367,7 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
-  it("deletes a thing", () => {
+  it("deletes a thing by id only", () => {
     return client.data
       .deleter()
       .withId("1565c06c-463f-466c-9092-5930dbac3887")
@@ -350,7 +375,7 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
-  it("checks that object doesn't exist anymore", () => {
+  it("checks that object doesn't exist anymore with delete by id only", () => {
     return client.data
       .checker()
       .withId("1565c06c-463f-466c-9092-5930dbac3887")
@@ -363,18 +388,11 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   });
 
-  it("waits for es index updates", () => {
-    return new Promise((resolve, reject) => {
-      // TODO: remove in 1.0.0
-      setTimeout(resolve, 1000);
-    });
-  });
-
-  it("deletes a thing with class name", async () => {
+  it("deletes a thing with id and class name", async () => {
     const properties = { stringProp: "with-id" };
     const id = "6781a974-cfbf-455d-ace8-f1dba4564230";
 
-    client.data
+    await client.data
       .creator()
       .withClassName(thingClassName)
       .withProperties(properties)
@@ -393,6 +411,19 @@ describe("data", () => {
       .do()
       .catch((e) => fail("it should not have errord: " + e));
   })
+
+  it("checks that object doesn't exist anymore with delete by id and class name", () => {
+    return client.data
+      .checker()
+      .withId("6781a974-cfbf-455d-ace8-f1dba4564230")
+      .do()
+      .then((exists) => {
+        if (exists) {
+          fail("it should not exist in DB")
+        }
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  });
 
   it("verifies there are now fewer things (after delete)", () => {
     return Promise.all([

--- a/data/merger.js
+++ b/data/merger.js
@@ -1,4 +1,5 @@
 import { isValidStringProperty } from "../validation/string";
+import { buildObjectsPath } from "./path";
 
 export default class Merger {
   constructor(client) {
@@ -55,7 +56,8 @@ export default class Merger {
         new Error("invalid usage: " + this.errors.join(", "))
       );
     }
-    const path = `/objects/${this.id}`;
+
+    const path = buildObjectsPath(this.id, this.className);
     return this.client.patch(path, this.payload());
   };
 }

--- a/data/path.js
+++ b/data/path.js
@@ -1,7 +1,7 @@
 import { isValidStringProperty } from "../validation/string";
 
 export function buildObjectsPath(id, className) {
-  let path = `/objects`;
+  let path = `objects`;
   if (isValidStringProperty(className)) {
     path = `${path}/${className}`;
   }

--- a/data/path.js
+++ b/data/path.js
@@ -1,0 +1,9 @@
+import { isValidStringProperty } from "../validation/string";
+
+export function buildObjectsPath(id, className) {
+  let path = `/objects`;
+  if (isValidStringProperty(className)) {
+    path = `${path}/${className}`;
+  }
+  return `/${path}/${id}`;
+}

--- a/data/updater.js
+++ b/data/updater.js
@@ -39,6 +39,14 @@ export default class Updater {
     }
   };
 
+  buildPath = () => {
+    let path = `/objects`;
+    if (isValidStringProperty(this.className)) {
+      path = `${path}/${this.className}`
+    }
+    return `/${path}/${this.id}`;
+  }
+
   payload = () => ({
     properties: this.properties,
     class: this.className,
@@ -58,7 +66,7 @@ export default class Updater {
         new Error("invalid usage: " + this.errors.join(", "))
       );
     }
-    const path = `/objects/${this.id}`;
+    const path = this.buildPath();
     return this.client.put(path, this.payload());
   };
 }

--- a/data/updater.js
+++ b/data/updater.js
@@ -1,4 +1,5 @@
 import { isValidStringProperty } from "../validation/string";
+import { buildObjectsPath } from "./path";
 
 export default class Updater {
   constructor(client) {
@@ -25,7 +26,7 @@ export default class Updater {
     if (!isValidStringProperty(this.className)) {
       this.errors = [
         ...this.errors,
-        "className must be set - set with withId(id)",
+        "className must be set - use withClassName(className)",
       ];
     }
   };
@@ -38,14 +39,6 @@ export default class Updater {
       ];
     }
   };
-
-  buildPath = () => {
-    let path = `/objects`;
-    if (isValidStringProperty(this.className)) {
-      path = `${path}/${this.className}`
-    }
-    return `/${path}/${this.id}`;
-  }
 
   payload = () => ({
     properties: this.properties,
@@ -66,7 +59,8 @@ export default class Updater {
         new Error("invalid usage: " + this.errors.join(", "))
       );
     }
-    const path = this.buildPath();
+
+    const path = buildObjectsPath(this.id, this.className);
     return this.client.put(path, this.payload());
   };
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3.4'
 services:
   weaviate:
-    image: semitechnologies/weaviate:1.13.2
+    # TODO: temporarily use this version until next release
+    image: semitechnologies/weaviate:latest@sha256:248a1e1f6f0ba817c00ead4edeecf9d19961d482a3c432165d95762bd44e3a0c
     restart: on-failure:0
     ports:
      - "8080:8080"

--- a/misc/journey.test.js
+++ b/misc/journey.test.js
@@ -70,4 +70,20 @@ describe("misc endpoints", () => {
       })
       .catch((e) => fail("it should not have errord: " + e));
   });
+
+  it("fetches the server version", async () => {
+    let version = await client.misc.metaGetter()
+      .do()
+      .then(res => {
+        return res.version;
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.misc.metaGetter()
+      .fetchVersion()
+      .then(res => {
+        expect(res).toEqual(version);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  });
 });

--- a/misc/metaGetter.js
+++ b/misc/metaGetter.js
@@ -6,4 +6,14 @@ export default class MetaGetter {
   do = () => {
     return this.client.get("/meta", true);
   };
+
+  fetchVersion = () => {
+    return this.client.get("/meta", true)
+      .then(res => {
+        return res.version;
+      })
+      .catch(err => {
+        return Promise.reject(err);
+      });
+  }
 }


### PR DESCRIPTION
This PR contains updates for the following endpoints:

- `GET /v1/objects/{className}/{id}`
- `DELETE /v1/objects/{className}/{id}`
- `PUT /v1/objects/{className}/{id}`
- `PATCH /v1/objects/{className}/{id}`
- `HEAD /v1/objects/{className}/{id}`