### PR TITLE
Add offset parameter for getter

### DIFF
--- a/data/getter.js
+++ b/data/getter.js
@@ -16,6 +16,11 @@ export default class Getter {
     return this;
   };
 
+  withOffset = (offset) => {
+    this.offset = offset;
+    return this;
+  };
+
   extendAdditionals = (prop) => {
     this.additionals = [...this.additionals, prop];
     return this;
@@ -32,7 +37,7 @@ export default class Getter {
       );
     }
 
-    return this.objectsPath.buildGet(this.className, this.limit, this.additionals)
+    return this.objectsPath.buildGet(this.className, this.limit, this.offset, this.additionals)
       .then(this.client.get);
   };
 }

--- a/data/journey.test.js
+++ b/data/journey.test.js
@@ -170,6 +170,7 @@ describe("data", () => {
       .withAdditional("nearestNeighbors")
       .withAdditional("featureProjection")
       .withVector()
+      .withOffset(2)
       .withLimit(2)
       .do()
       .then((res) => {

--- a/data/path.js
+++ b/data/path.js
@@ -20,8 +20,8 @@ export class ObjectsPath {
   buildGetOne(id, className, additionals) {
     return this.build({id, className, additionals}, [this.addClassNameDeprecatedNotSupportedCheck, this.addId, this.addQueryParams]);
   }
-  buildGet(className, limit, additionals) {
-    return this.build({className, limit, additionals}, [this.addQueryParamsForGet]);
+  buildGet(className, limit, offset, additionals) {
+    return this.build({className, limit, offset, additionals}, [this.addQueryParamsForGet]);
   }
   buildUpdate(id, className) {
     return this.build({id, className}, [this.addClassNameDeprecatedCheck, this.addId]);
@@ -85,6 +85,9 @@ export class ObjectsPath {
     }
     if (typeof params.limit == "number" && params.limit > 0) {
       queryParams.push(`limit=${params.limit}`);
+    }
+    if (typeof params.offset == "number" && params.offset > 0) {
+      queryParams.push(`offset=${params.offset}`);
     }
     if (isValidStringProperty(params.className)) {
       if (support.supports) {


### PR DESCRIPTION
This adds an offset parameter to the objects getter to be able to paginate through results.

As discussed here: https://weaviate.slack.com/archives/C02RRQP23K3/p1662041793768329.

Feel free to use this code at your discretion in your own commits if needed.